### PR TITLE
Remove unused @NotBlank import from UpdateOrganisationRequest

### DIFF
--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/payloads/UpdateOrganisationRequest.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/payloads/UpdateOrganisationRequest.java
@@ -1,6 +1,5 @@
 package com.qbitspark.buildwisebackend.organisationService.payloads;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data


### PR DESCRIPTION
The @NotBlank import was unused in the UpdateOrganisationRequest class and has now been removed to clean up the code. This helps maintain clarity and avoids unnecessary imports in the file.