### PR TITLE
Refactor AccountRepo usage and implement organisation member management

### DIFF
--- a/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/Repository/AccountRepo.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/Repository/AccountRepo.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface GlobeAccountRepository extends JpaRepository<AccountEntity, UUID> {
+public interface AccountRepo extends JpaRepository<AccountEntity, UUID> {
     Optional<AccountEntity> findAccountEntitiesByEmailOrPhoneNumberOrUserName(String email, String phoneNumber, String userName);
     Optional<AccountEntity> findAccountEntitiesByUserName(String userName);
     Optional<AccountEntity> findByEmail(String email);

--- a/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/Service/IMPL/PasswordResetOTPServiceIMPL.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/Service/IMPL/PasswordResetOTPServiceIMPL.java
@@ -7,7 +7,7 @@ import com.qbitspark.buildwisebackend.globeadvice.exceptions.VerificationExcepti
 import com.qbitspark.buildwisebackend.globeauthentication.Repository.PasswordResetOTPRepo;
 import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
 import com.qbitspark.buildwisebackend.globeauthentication.entity.PasswordResetOTPEntity;
-import com.qbitspark.buildwisebackend.globeauthentication.Repository.GlobeAccountRepository;
+import com.qbitspark.buildwisebackend.globeauthentication.Repository.AccountRepo;
 import com.qbitspark.buildwisebackend.globeauthentication.Repository.UserOTPRepository;
 import com.qbitspark.buildwisebackend.globeauthentication.Service.EmailOTPService;
 import com.qbitspark.buildwisebackend.globeauthentication.Service.PasswordResetOTPService;
@@ -26,7 +26,7 @@ public class PasswordResetOTPServiceIMPL implements PasswordResetOTPService {
     @Value("${otp.expire_time.minutes}")
     private String EXPIRE_TIME;
 
-   private final GlobeAccountRepository globeAccountRepository;
+   private final AccountRepo accountRepo;
     private final CustomValidationUtils validationUtils;
     private final PasswordEncoder passwordEncoder;
     private final EmailOTPService emailOTPService;
@@ -36,7 +36,7 @@ public class PasswordResetOTPServiceIMPL implements PasswordResetOTPService {
     @Override
     public String generateAndSendPSWDResetOTP(String email) throws RandomExceptions, JsonProcessingException, ItemNotFoundException {
 
-            AccountEntity accountEntity = globeAccountRepository.findByEmail(email)
+            AccountEntity accountEntity = accountRepo.findByEmail(email)
                 .orElseThrow(()-> new ItemNotFoundException("No such user with given email"));
 
             if (accountEntity.getIsVerified().equals(false)){
@@ -60,7 +60,7 @@ public class PasswordResetOTPServiceIMPL implements PasswordResetOTPService {
     public boolean verifyOTPAndResetPassword(String email, String otpCode, String newPassword) throws RandomExceptions, ItemNotFoundException, VerificationException {
 
         // Fetch the user by phone number
-        AccountEntity account = globeAccountRepository.findByEmail(email)
+        AccountEntity account = accountRepo.findByEmail(email)
                 .orElseThrow(() -> new ItemNotFoundException("No such user with given phone number"));
 
         PasswordResetOTPEntity existingOTP = passwordResetOTPRepo.findPasswordResetOTPEntitiesByAccount(account);
@@ -85,7 +85,7 @@ public class PasswordResetOTPServiceIMPL implements PasswordResetOTPService {
 
                 // Reset the password
                 account.setPassword(passwordEncoder.encode(newPassword));
-                globeAccountRepository.save(account);
+                accountRepo.save(account);
 
                 // Make the OTP expire after a successful password reset
                 LocalDateTime expiration = existingOTP.getSentTime().minusHours(20);

--- a/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/Service/IMPL/SMSOTPIMPL.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/Service/IMPL/SMSOTPIMPL.java
@@ -8,7 +8,7 @@ import com.qbitspark.buildwisebackend.globeadvice.exceptions.RandomExceptions;
 import com.qbitspark.buildwisebackend.globeadvice.exceptions.VerificationException;
 import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
 import com.qbitspark.buildwisebackend.globeauthentication.entity.UserOTP;
-import com.qbitspark.buildwisebackend.globeauthentication.Repository.GlobeAccountRepository;
+import com.qbitspark.buildwisebackend.globeauthentication.Repository.AccountRepo;
 import com.qbitspark.buildwisebackend.globeauthentication.Repository.UserOTPRepository;
 import com.qbitspark.buildwisebackend.globeauthentication.Service.SMSOTPService;
 import com.qbitspark.buildwisebackend.globesecurity.JWTProvider;
@@ -30,7 +30,7 @@ import java.util.Random;
 public class SMSOTPIMPL implements SMSOTPService {
 
     private final UserOTPRepository userOTPRepository;
-    private final GlobeAccountRepository userManagerRepository;
+    private final AccountRepo userManagerRepository;
 
     private final JWTProvider tokenProvider;
     private final BasicAuthApiClient basicAuthApiClient;
@@ -102,7 +102,7 @@ public class SMSOTPIMPL implements SMSOTPService {
         throw new VerificationException("OTP or phone number provided is incorrect");
     }
 
-    static GlobeSuccessResponseBuilder buildSMSSuccessResponse(AccountEntity user, LocalDateTime currentTime, LocalDateTime expirationTime, GlobeAccountRepository userManagerRepository, JWTProvider tokenProvider) {
+    static GlobeSuccessResponseBuilder buildSMSSuccessResponse(AccountEntity user, LocalDateTime currentTime, LocalDateTime expirationTime, AccountRepo userManagerRepository, JWTProvider tokenProvider) {
         if (currentTime.isBefore(expirationTime)) {
             // Mark the user as verified
             user.setIsVerified(true);

--- a/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/controller/OTPController.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/globeauthentication/controller/OTPController.java
@@ -7,7 +7,7 @@ import com.qbitspark.buildwisebackend.globeadvice.exceptions.VerificationExcepti
 import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
 import com.qbitspark.buildwisebackend.globeauthentication.payloads.EmailOTPRequestBody;
 import com.qbitspark.buildwisebackend.globeauthentication.payloads.RequestEmailOTPBody;
-import com.qbitspark.buildwisebackend.globeauthentication.Repository.GlobeAccountRepository;
+import com.qbitspark.buildwisebackend.globeauthentication.Repository.AccountRepo;
 import com.qbitspark.buildwisebackend.globeauthentication.Service.EmailOTPService;
 import com.qbitspark.buildwisebackend.globeauthentication.Service.SMSOTPService;
 import com.qbitspark.buildwisebackend.globeresponsebody.GlobeSuccessResponseBuilder;
@@ -25,13 +25,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class OTPController {
 
     private final SMSOTPService smsotpService;
-    private final GlobeAccountRepository globeAccountRepository;
+    private final AccountRepo accountRepo;
     private final EmailOTPService emailOTPService;
 
     @PostMapping("/request-otp")
     public ResponseEntity<GlobeSuccessResponseBuilder> requestEmailOTP(@Valid @RequestBody RequestEmailOTPBody requestEmailOTPBody) throws RandomExceptions, JsonProcessingException, ItemNotFoundException {
 
-        AccountEntity userAuthEntity = globeAccountRepository.findByEmail(requestEmailOTPBody.getEmail())
+        AccountEntity userAuthEntity = accountRepo.findByEmail(requestEmailOTPBody.getEmail())
                 .orElseThrow(() -> new ItemNotFoundException("User with provided email does not exist"));
 
         // Send the OTP via Email for password reset

--- a/src/main/java/com/qbitspark/buildwisebackend/globesecurity/CustomUserDetailsService.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/globesecurity/CustomUserDetailsService.java
@@ -3,7 +3,7 @@ package com.qbitspark.buildwisebackend.globesecurity;
 
 import com.qbitspark.buildwisebackend.globeadvice.exceptions.ItemReadyExistException;
 import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
-import com.qbitspark.buildwisebackend.globeauthentication.Repository.GlobeAccountRepository;
+import com.qbitspark.buildwisebackend.globeauthentication.Repository.AccountRepo;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.security.core.GrantedAuthority;
@@ -21,13 +21,13 @@ import java.util.stream.Collectors;
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final GlobeAccountRepository globeAccountRepository;
+    private final AccountRepo accountRepo;
 
     @SneakyThrows
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-        AccountEntity user = globeAccountRepository.findAccountEntitiesByUserName(username)
+        AccountEntity user = accountRepo.findAccountEntitiesByUserName(username)
                 .orElseThrow(() -> new ItemReadyExistException("User with given username not found: " + username));
 
         Set<GrantedAuthority> authorities =

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/organisation_mng/service/impl/OrganisationServiceIMPL.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/organisation_mng/service/impl/OrganisationServiceIMPL.java
@@ -1,7 +1,7 @@
 package com.qbitspark.buildwisebackend.organisationService.organisation_mng.service.impl;
 
 import com.qbitspark.buildwisebackend.globeadvice.exceptions.ItemNotFoundException;
-import com.qbitspark.buildwisebackend.globeauthentication.Repository.GlobeAccountRepository;
+import com.qbitspark.buildwisebackend.globeauthentication.Repository.AccountRepo;
 import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
 import com.qbitspark.buildwisebackend.organisationService.organisation_mng.entity.OrganisationEntity;
 import com.qbitspark.buildwisebackend.organisationService.organisation_mng.payloads.CreateOrganisationRequest;
@@ -24,7 +24,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OrganisationServiceIMPL implements OrganisationService {
 
-    private final GlobeAccountRepository accountRepo;
+    private final AccountRepo accountRepo;
     private final OrganisationRepo organisationRepo;
 
     @Transactional

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/entities/OrganisationInvitation.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/entities/OrganisationInvitation.java
@@ -1,0 +1,48 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.entities;
+
+import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
+import com.qbitspark.buildwisebackend.organisationService.organisation_mng.entity.OrganisationEntity;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums.InvitationStatus;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums.MemberRole;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "organisation_invitations")
+public class OrganisationInvitation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID invitationId;
+
+    @ManyToOne
+    private OrganisationEntity organisation;
+
+    @ManyToOne
+    private AccountEntity inviter;
+
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Column(name = "token", columnDefinition = "TEXT", unique = true, nullable = false)
+    private String token; // Unique invitation token
+
+    @Enumerated(EnumType.STRING)
+    private InvitationStatus status; // PENDING, ACCEPTED, DECLINED, EXPIRED
+
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+    private LocalDateTime respondedAt;
+
+}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/entities/OrganisationMember.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/entities/OrganisationMember.java
@@ -1,0 +1,45 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.entities;
+
+import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
+import com.qbitspark.buildwisebackend.organisationService.organisation_mng.entity.OrganisationEntity;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums.MemberRole;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums.MemberStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "organisation_members")
+public class OrganisationMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID memberId;
+
+    @ManyToOne
+    @JoinColumn(name = "organisation_id")
+    private OrganisationEntity organisation;
+
+    @ManyToOne
+    @JoinColumn(name = "account_id")
+    private AccountEntity account;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role; // OWNER, ADMIN, MEMBER
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status; // ACTIVE, SUSPENDED, LEFT
+
+    private LocalDateTime joinedAt;
+
+    private UUID invitedBy;
+
+}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/enums/InvitationStatus.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/enums/InvitationStatus.java
@@ -1,0 +1,10 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums;
+
+public enum InvitationStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+    EXPIRED,
+    REVOKED
+}
+

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/enums/MemberRole.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/enums/MemberRole.java
@@ -1,0 +1,7 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums;
+
+public enum MemberRole {
+    OWNER,   // Can do everything, delete org
+    ADMIN,   // Can invite/manage members, can't delete org
+    MEMBER   // Basic access, can't manage members
+}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/enums/MemberStatus.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/enums/MemberStatus.java
@@ -1,0 +1,7 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums;
+
+public enum MemberStatus {
+    ACTIVE,
+    SUSPENDED,
+    LEFT
+}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/repo/OrganisationInvitationRepo.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/repo/OrganisationInvitationRepo.java
@@ -1,0 +1,17 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.repo;
+
+import com.qbitspark.buildwisebackend.organisationService.organisation_mng.entity.OrganisationEntity;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.entities.OrganisationInvitation;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums.InvitationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrganisationInvitationRepo extends JpaRepository<OrganisationInvitation, UUID> {
+    Optional<OrganisationInvitation> findByToken(String token);
+    boolean existsByEmailAndOrganisationAndStatus(String email, OrganisationEntity organisation, InvitationStatus status);
+
+    Optional<OrganisationInvitation> findByEmailAndOrganisationAndStatus(String email, OrganisationEntity organisation, InvitationStatus status);
+
+}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/repo/OrganisationMemberRepo.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/repo/OrganisationMemberRepo.java
@@ -1,0 +1,16 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.repo;
+
+import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
+import com.qbitspark.buildwisebackend.organisationService.organisation_mng.entity.OrganisationEntity;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.entities.OrganisationMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrganisationMemberRepo extends JpaRepository<OrganisationMember, UUID> {
+
+    boolean existsByAccountEmailAndOrganisation(String email, OrganisationEntity organisation);
+
+    Optional<OrganisationMember> findByAccountAndOrganisation(AccountEntity account, OrganisationEntity organisation);
+}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/service/OrganisationMemberService.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/service/OrganisationMemberService.java
@@ -1,0 +1,14 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.service;
+
+import com.qbitspark.buildwisebackend.globeadvice.exceptions.AccessDeniedException;
+import com.qbitspark.buildwisebackend.globeadvice.exceptions.ItemNotFoundException;
+
+import java.util.UUID;
+
+public interface OrganisationMemberService {
+
+    boolean inviteMember(UUID organisationId, String email, String role) throws ItemNotFoundException, AccessDeniedException;
+
+    boolean acceptInvitation(String token);
+
+}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/service/OrganisationMembersService.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/service/OrganisationMembersService.java
@@ -1,5 +1,0 @@
-package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.service;
-
-public interface OrganisationMembersService {
-
-}

--- a/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/service/impl/OrganisationMemberServiceIMPL.java
+++ b/src/main/java/com/qbitspark/buildwisebackend/organisationService/orgnisation_members_mng/service/impl/OrganisationMemberServiceIMPL.java
@@ -1,0 +1,144 @@
+package com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.service.impl;
+
+import com.qbitspark.buildwisebackend.globeadvice.exceptions.AccessDeniedException;
+import com.qbitspark.buildwisebackend.globeadvice.exceptions.ItemNotFoundException;
+import com.qbitspark.buildwisebackend.globeauthentication.Repository.AccountRepo;
+import com.qbitspark.buildwisebackend.globeauthentication.entity.AccountEntity;
+import com.qbitspark.buildwisebackend.organisationService.organisation_mng.entity.OrganisationEntity;
+import com.qbitspark.buildwisebackend.organisationService.organisation_mng.repo.OrganisationRepo;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.entities.OrganisationInvitation;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.entities.OrganisationMember;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums.InvitationStatus;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.enums.MemberRole;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.repo.OrganisationInvitationRepo;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.repo.OrganisationMemberRepo;
+import com.qbitspark.buildwisebackend.organisationService.orgnisation_members_mng.service.OrganisationMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OrganisationMemberServiceIMPL implements OrganisationMemberService {
+
+    private final OrganisationMemberRepo organisationMemberRepo;
+    private final AccountRepo accountRepo;
+    private final OrganisationRepo organisationRepo;
+    private final OrganisationInvitationRepo organisationInvitationRepo;
+
+    @Transactional
+    @Override
+    public boolean inviteMember(UUID organisationId, String email, String role) throws ItemNotFoundException, AccessDeniedException {
+
+            // Step 0: Check authenticated user permissions FIRST
+            AccountEntity currentUser = getAuthenticatedAccount();
+
+            // Step 1: Get the organisation
+            OrganisationEntity organisation = organisationRepo.findById(organisationId)
+                    .orElseThrow(() -> new ItemNotFoundException("Organisation not found"));
+
+            // Step 2: Check if the current user can manage members in this org
+            if (!canManageMembers(currentUser, organisation)) {
+                throw new AccessDeniedException("You do not have permission to manage members in this organisation");
+            }
+
+            // Step 3: Check if email is already a member
+            if (organisationMemberRepo.existsByAccountEmailAndOrganisation(email, organisation)) {
+                return false; // Already a member
+            }
+
+            // Step 4: Check if email already has valid pending invitation
+            if (hasValidPendingInvitation(email, organisation)) {
+                return false; // Already has a valid invitation
+            }
+
+            // Step 5: Create invitation
+            // TODO: Generate token, set fields, save invitation
+            OrganisationInvitation invitation = new OrganisationInvitation();
+            invitation.setOrganisation(organisation);
+            invitation.setInviter(currentUser);
+            invitation.setEmail(email);
+            invitation.setRole(MemberRole.valueOf(role)); // Convert string to enum
+            invitation.setToken(generateUniqueToken());
+            invitation.setStatus(InvitationStatus.PENDING);
+            invitation.setCreatedAt(LocalDateTime.now());
+            invitation.setExpiresAt(LocalDateTime.now().plusDays(7)); // 7 days expiry
+
+            return true;
+
+    }
+
+    @Override
+    public boolean acceptInvitation(String token) {
+        return false;
+    }
+
+
+    private AccountEntity getAuthenticatedAccount() throws ItemNotFoundException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return extractAccount(authentication);
+    }
+
+
+    private boolean hasValidPendingInvitation(String email, OrganisationEntity organisation) {
+        Optional<OrganisationInvitation> existingInvitation = organisationInvitationRepo
+                .findByEmailAndOrganisationAndStatus(email, organisation, InvitationStatus.PENDING);
+
+        if (existingInvitation.isPresent()) {
+            OrganisationInvitation invitation = existingInvitation.get();
+
+            if (invitation.getExpiresAt().isAfter(LocalDateTime.now())) {
+                return true; // Valid pending invitation exists
+            } else {
+                // Mark as expired
+                invitation.setStatus(InvitationStatus.EXPIRED);
+                organisationInvitationRepo.save(invitation);
+                return false; // No valid pending invitation
+            }
+        }
+
+        return false; // No pending invitation
+    }
+
+
+    private boolean canManageMembers(AccountEntity user, OrganisationEntity organisation) {
+        // Check if user is OWNER or ADMIN of this organisation
+        Optional<OrganisationMember> membership = organisationMemberRepo
+                .findByAccountAndOrganisation(user, organisation);
+
+        if (membership.isPresent()) {
+            MemberRole role = membership.get().getRole();
+            return role == MemberRole.OWNER || role == MemberRole.ADMIN;
+        }
+
+        return false; // Not a member, can't manage
+    }
+
+    private String generateUniqueToken() {
+        return UUID.randomUUID().toString() + "-" + System.currentTimeMillis();
+    }
+
+
+    private AccountEntity extractAccount(Authentication authentication) throws ItemNotFoundException {
+        if (authentication != null && authentication.isAuthenticated()) {
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            String userName = userDetails.getUsername();
+
+            Optional<AccountEntity> userOptional = accountRepo.findByUserName(userName);
+            if (userOptional.isPresent()) {
+                return userOptional.get();
+            } else {
+                throw new ItemNotFoundException("User with given userName does not exist");
+            }
+        } else {
+            throw new ItemNotFoundException("User is not authenticated");
+        }
+    }
+}


### PR DESCRIPTION
Replaced `GlobeAccountRepository` with `AccountRepo` across services and controllers for consistency. Added organisation member management functionality, including invitation creation, token generation, and permissions validation, with necessary enums and repositories.